### PR TITLE
Use drupal 8.3.x as a facets test-dependency.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -54,7 +54,7 @@ install:
   - echo "error_log=syslog" >> `php --ini | grep "Loaded Configuration" | awk '{print $4}'`
   # Get latest Drupal 8 core
   - cd $TRAVIS_BUILD_DIR/..
-  - git clone --branch 8.2.x https://git.drupal.org/project/drupal.git
+  - git clone --branch 8.3.x https://git.drupal.org/project/drupal.git
   - cd $TRAVIS_BUILD_DIR/../drupal
   - composer install
   - composer config repositories.drupal composer https://packages.drupal.org/8


### PR DESCRIPTION
Facets has some tests that remove a block, the UI text for removing a block has changed between 8.2 and 8.3. Because the testbots run on 8.3.x, we've also updated the facets code.

Updating drupal to 8.3 should resolve those test-errors
